### PR TITLE
fix (Quran-51): Only load translation per locale

### DIFF
--- a/src/blocks/QuranReader/partials/TranslationViewCell.tsx
+++ b/src/blocks/QuranReader/partials/TranslationViewCell.tsx
@@ -13,6 +13,8 @@ import { AudioPlayerMachineContext } from '~/xstate/AudioPlayerMachineContext'
 import { selectEnableAutoScrolling } from '~/store/slices/AudioPlayer/state'
 import PlayVerseAudioButton from '~/components/Verse/PlayVerseAudioButton'
 import VerseLink from '~/components/VerseLink'
+import useGetQueryParamOrReduxValue from '~/hooks/useGetQueryParamOrReduxValue'
+import QueryParam from '~/types/QueryParam'
 import {
   verseFontChanged,
   verseTranslationChanged,
@@ -69,28 +71,9 @@ const TranslationViewCellActionsLeft = styled('div')(({ theme }) => ({
   },
 }))
 
-const TranslationViewCellActionsRight = styled(TranslationViewCellActionsLeft)(() => ({
-  justifyContent: 'flex-end',
-}))
-
 const TranslationViewCellContentContainer = styled('div')(({ theme }) => ({
   flex: 1,
   position: 'relative',
-}))
-
-const TranslationViewCellWordsContainer = styled('div')(() => ({
-  display: 'flex',
-  paddingLeft: '2.5rem',
-  paddingRight: '0.5rem',
-  flexDirection: 'column',
-  flexGrow: 1,
-  gap: '1.25rem',
-  justifyContent: 'center',
-}))
-const TranslationViewCellWords = styled('div')(() => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: '0.5rem',
 }))
 
 type TranslationViewCellProps = {
@@ -104,6 +87,22 @@ type TranslationViewCellProps = {
 
 function TranslationViewCell(props: TranslationViewCellProps) {
   const { verse, quranReaderStyles, verseIndex, pageBookmarks, bookmarksRangeUrl, locale } = props
+
+  const {
+    value: selectedTranslations,
+    isQueryParamDifferent: translationsQueryParamDifferent,
+  }: { value: number[]; isQueryParamDifferent: boolean } = useGetQueryParamOrReduxValue(
+    QueryParam.Translations,
+  )
+
+  const filteredTranslations = React.useMemo(
+    () =>
+      verse.translations?.filter((item) =>
+        selectedTranslations?.includes(item.resourceId as number),
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedTranslations],
+  )
 
   const router = useRouter()
   const { startingVerse } = router.query
@@ -184,7 +183,7 @@ function TranslationViewCell(props: TranslationViewCellProps) {
               marginBlockEnd: { md: 'calc(1.3 * var(--gap-size))' },
             }}
           >
-            {verse.translations?.map((translation: Translation) => (
+            {filteredTranslations?.map((translation: Translation) => (
               <Box
                 key={translation.id}
                 sx={{


### PR DESCRIPTION
**Ticket Link:** [QURAN-51](https://novatechsolutions.atlassian.net/browse/QURAN-51)

**Description:**
This PR fixes translation per locale

**Local Testing Instructions:**
1. Go to `http://localhost:3000/surah/1`
2. Should be possible to see one translation per locale.

**Screenshots:**
- Before:

<img width="1580" alt="image" src="https://github.com/Studerakoranen-se/quran-dotcom-web/assets/10485129/4088d8e6-8cac-4f11-8f12-3f9bf058073a">

- After:

<img width="1589" alt="image" src="https://github.com/Studerakoranen-se/quran-dotcom-web/assets/10485129/430cc48e-086b-4595-9ea6-a7daa308b4e5">

<img width="1592" alt="image" src="https://github.com/Studerakoranen-se/quran-dotcom-web/assets/10485129/9ccb7c8b-3748-464a-ae78-e201263860d8">